### PR TITLE
Eliminate type duplication between schemas and reference implementation

### DIFF
--- a/reference/trace-store.ts
+++ b/reference/trace-store.ts
@@ -1,48 +1,19 @@
 import { execFileSync } from "child_process";
 import { existsSync, mkdirSync, appendFileSync, readFileSync } from "fs";
 import { join, relative } from "path";
+import type {
+  ContributorType,
+  Conversation,
+  File as FileEntry,
+  Range,
+  Tool,
+  TraceRecord,
+  Vcs,
+  VcsType,
+} from "../schemas";
 
-export interface Range {
-  start_line: number;
-  end_line: number;
-  content_hash?: string;
-  contributor?: {
-    type: "human" | "ai" | "mixed" | "unknown";
-    model_id?: string;
-  };
-}
-
-export interface Conversation {
-  url?: string;
-  contributor?: {
-    type: "human" | "ai" | "mixed" | "unknown";
-    model_id?: string;
-  };
-  ranges: Range[];
-  related?: { type: string; url: string }[];
-}
-
-export interface FileEntry {
-  path: string;
-  conversations: Conversation[];
-}
-
-export type VcsType = "git" | "jj" | "hg" | "svn";
-
-export interface Vcs {
-  type: VcsType;
-  revision: string;
-}
-
-export interface TraceRecord {
-  version: string;
-  id: string;
-  timestamp: string;
-  vcs?: Vcs;
-  tool?: { name: string; version?: string };
-  files: FileEntry[];
-  metadata?: Record<string, unknown>;
-}
+// Re-export schema types for consumers
+export type { ContributorType, Conversation, FileEntry, Range, Tool, TraceRecord, Vcs, VcsType };
 
 export interface FileEdit {
   old_string: string;
@@ -59,7 +30,7 @@ export function getWorkspaceRoot(): string {
     ?? process.cwd();
 }
 
-export function getToolInfo(): { name: string; version?: string } {
+export function getToolInfo(): Tool {
   if (process.env.CURSOR_VERSION) return { name: "cursor", version: process.env.CURSOR_VERSION };
   if (process.env.CLAUDE_PROJECT_DIR) return { name: "claude-code" };
   return { name: "unknown" };
@@ -120,8 +91,6 @@ export function computeRangePositions(edits: FileEdit[], fileContent?: string): 
       return { start_line: 1, end_line: lineCount };
     });
 }
-
-export type ContributorType = "human" | "ai" | "mixed" | "unknown";
 
 export function createTrace(
   type: ContributorType,

--- a/schemas.ts
+++ b/schemas.ts
@@ -12,7 +12,7 @@ export const ContributorTypeSchema = z.enum([
 
 export const ToolSchema = z.object({
   name: z.string().describe("Name of the tool that produced the code"),
-  version: z.string().describe("Version of the tool"),
+  version: z.string().optional().describe("Version of the tool"),
 });
 
 export const ContributorSchema = z.object({


### PR DESCRIPTION
## Problem

Type definitions were duplicated between `schemas.ts` and `reference/trace-store.ts`, creating maintenance burden and risk of divergence.

## Solution

Import types from the canonical source (`schemas.ts`) instead of redefining them.

## Changes

| File | Change |
|------|--------|
| `reference/trace-store.ts` | Import types from `schemas.ts` instead of local definitions |
| `schemas.ts` | Make `Tool.version` optional to match implementation |

## Types Consolidated

| Type | Before | After |
|------|--------|-------|
| `Range` | Defined in both files | Single source in `schemas.ts` |
| `Conversation` | Defined in both files | Single source in `schemas.ts` |
| `FileEntry` | Defined in both files | Alias for `File` from `schemas.ts` |
| `Vcs` | Defined in both files | Single source in `schemas.ts` |
| `VcsType` | Defined in both files | Single source in `schemas.ts` |
| `TraceRecord` | Defined in both files | Single source in `schemas.ts` |
| `ContributorType` | Defined in both files | Single source in `schemas.ts` |
| `Tool` | Not used in trace-store | Now imported and used |

## Schema Fix

| Field | Before | After | Reason |
|-------|--------|-------|--------|
| `Tool.version` | Required | Optional | `getToolInfo()` doesn't always return version (e.g., claude-code) |

## Impact

- **-46 lines** of duplicate type definitions removed
- **+15 lines** of imports and re-exports added
- Types now re-exported from `trace-store.ts` for backward compatibility