### PR TITLE
fix(reference): Fix line attribution accuracy and add Claude Code model extraction

### DIFF
--- a/reference/trace-store.ts
+++ b/reference/trace-store.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync, mkdirSync, appendFileSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, appendFileSync, readFileSync, openSync, fstatSync, readSync, closeSync } from "fs";
 import { join, relative } from "path";
 
 export interface Range {
@@ -94,30 +94,187 @@ export function normalizeModelId(model?: string): string | undefined {
   return model;
 }
 
+/**
+ * Extracts the model identifier from a Claude Code transcript file.
+ *
+ * Claude Code stores conversation transcripts as JSONL files where each line
+ * represents a message exchange. The model identifier is stored at `entry.message.model`.
+ * This function reads only the tail of the file to efficiently get the most recent model,
+ * which handles cases where the model may have changed during a session.
+ *
+ * @param transcriptPath - Absolute path to the Claude Code transcript JSONL file
+ * @returns The model identifier (e.g., "claude-opus-4-5-20251101") or undefined if not found
+ *
+ * @example
+ * ```typescript
+ * const model = extractModelFromTranscript("/path/to/transcript.jsonl");
+ * // Returns: "claude-opus-4-5-20251101"
+ * ```
+ */
+export function extractModelFromTranscript(transcriptPath: string): string | undefined {
+  try {
+    const fd = openSync(transcriptPath, "r");
+    const stats = fstatSync(fd);
+
+    // Start with 4KB, expand if needed (balances syscall overhead vs read size)
+    let readSize = Math.min(stats.size, 4 * 1024);
+
+    while (readSize <= stats.size) {
+      const buffer = Buffer.alloc(readSize);
+      readSync(fd, buffer, 0, readSize, stats.size - readSize);
+
+      const content = buffer.toString("utf-8");
+      const lines = content.split("\n");
+
+      // Iterate from end to get the most recent model
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        try {
+          const entry = JSON.parse(line);
+          if (entry.message?.model) {
+            closeSync(fd);
+            return entry.message.model;
+          }
+        } catch {
+          // Skip malformed/partial JSON lines
+          continue;
+        }
+      }
+
+      // No model found, try larger chunk
+      if (readSize >= stats.size) break;
+      readSize = Math.min(stats.size, readSize * 2);
+    }
+
+    closeSync(fd);
+    return undefined;
+  } catch {
+    // File doesn't exist or isn't readable
+    return undefined;
+  }
+}
+
 export interface RangePosition {
   start_line: number;
   end_line: number;
 }
 
+/**
+ * Computes which lines in `newStr` are actually new or modified compared to `oldStr`.
+ *
+ * This function performs a simple line-by-line diff to distinguish between:
+ * - Context lines: Lines that exist in both old and new strings (not attributed)
+ * - Changed lines: Lines that are new or modified (attributed to AI)
+ *
+ * This is necessary because some tools (like Claude Code's Edit tool) include
+ * surrounding context lines in both `old_string` and `new_string`. Without this
+ * diff, we would incorrectly attribute unchanged context lines to the AI.
+ *
+ * @param oldStr - The original string before the edit
+ * @param newStr - The new string after the edit
+ * @returns Array of 0-indexed line offsets within `newStr` that are new or modified
+ *
+ * @example
+ * ```typescript
+ * // old: "line1\nline2\nline3"
+ * // new: "line1\nNEW LINE\nline3"
+ * diffToFindChangedLines(old, new); // Returns [1] - only the middle line changed
+ * ```
+ */
+function diffToFindChangedLines(oldStr: string, newStr: string): number[] {
+  const oldLines = oldStr.split("\n");
+  const newLines = newStr.split("\n");
+  const changedOffsets: number[] = [];
+
+  let oldIdx = 0;
+
+  for (let newIdx = 0; newIdx < newLines.length; newIdx++) {
+    if (oldIdx < oldLines.length && oldLines[oldIdx] === newLines[newIdx]) {
+      // Matching line - this is context, not a change
+      oldIdx++;
+    } else {
+      // Check if this line from newStr exists later in oldStr (handles deletions)
+      let foundAhead = false;
+      for (let lookAhead = oldIdx; lookAhead < oldLines.length; lookAhead++) {
+        if (oldLines[lookAhead] === newLines[newIdx]) {
+          oldIdx = lookAhead + 1;
+          foundAhead = true;
+          break;
+        }
+      }
+
+      if (!foundAhead) {
+        // Line is genuinely new or modified - attribute to AI
+        changedOffsets.push(newIdx);
+      }
+    }
+  }
+
+  return changedOffsets;
+}
+
 export function computeRangePositions(edits: FileEdit[], fileContent?: string): RangePosition[] {
   return edits
     .filter((e) => e.new_string)
-    .map((edit) => {
+    .flatMap((edit) => {
+      // Case 1: Has explicit range from tool → use it
       if (edit.range) {
-        return {
+        return [{
           start_line: edit.range.start_line_number,
           end_line: edit.range.end_line_number,
-        };
+        }];
       }
+
+      // Case 2: Has both old_string and new_string → diff them to find actual changes
+      if (edit.old_string && edit.new_string && fileContent) {
+        const idx = fileContent.indexOf(edit.new_string);
+        if (idx !== -1) {
+          const startLine = fileContent.substring(0, idx).split("\n").length;
+          const changedOffsets = diffToFindChangedLines(edit.old_string, edit.new_string);
+
+          if (changedOffsets.length === 0) {
+            return [];
+          }
+
+          // Convert offsets to line ranges, merging adjacent lines
+          const ranges: RangePosition[] = [];
+          let rangeStart = changedOffsets[0];
+          let rangeEnd = changedOffsets[0];
+
+          for (let i = 1; i < changedOffsets.length; i++) {
+            if (changedOffsets[i] === rangeEnd + 1) {
+              rangeEnd = changedOffsets[i];
+            } else {
+              ranges.push({
+                start_line: startLine + rangeStart,
+                end_line: startLine + rangeEnd,
+              });
+              rangeStart = changedOffsets[i];
+              rangeEnd = changedOffsets[i];
+            }
+          }
+
+          ranges.push({
+            start_line: startLine + rangeStart,
+            end_line: startLine + rangeEnd,
+          });
+
+          return ranges;
+        }
+      }
+
+      // Case 3: Fallback - attribute entire new_string (original behavior)
       const lineCount = edit.new_string.split("\n").length;
       if (fileContent) {
         const idx = fileContent.indexOf(edit.new_string);
         if (idx !== -1) {
           const startLine = fileContent.substring(0, idx).split("\n").length;
-          return { start_line: startLine, end_line: startLine + lineCount - 1 };
+          return [{ start_line: startLine, end_line: startLine + lineCount - 1 }];
         }
       }
-      return { start_line: 1, end_line: lineCount };
+      return [{ start_line: 1, end_line: lineCount }];
     });
 }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  This PR fixes two correctness issues in the reference implementation affecting Claude Code trace accuracy:                                                                                                                             
                                                                                                                                                                                                                                         
  1. **Over-attribution of context lines** - Edits were claiming unchanged surrounding lines                                                                                                                                             
  2. **Missing model identification** - Claude Code traces had no `model_id`                                                                                                                                                             
                                                                                                                                                                                                                                         
  ## Problem Details                                                                                                                                                                                                                     
                                                                                                                                                                                                                                         
  ### Issue 1: Line Attribution                                                                                                                                                                                                          
                                                                                                                                                                                                                                         
  Claude Code's `Edit` tool includes context lines in both `old_string` and `new_string`. The previous implementation attributed the entire `new_string`, incorrectly claiming ownership of unchanged lines.                             
                                                                                                                                                                                                                                         
  **Before:** Adding 1 line → `ranges: [{start_line: 1, end_line: 3}]`                                                                                                                                                                   
  **After:** Adding 1 line → `ranges: [{start_line: 2, end_line: 2}]`                                                                                                                                                                    
                                                                                                                                                                                                                                         
  ### Issue 2: Model Identification                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  Unlike Cursor, Claude Code does not include `model` in hook payloads. The model must be extracted from the transcript JSONL file at `entry.message.model`.                                                                             
                                                                                                                                                                                                                                         
  ## Solution                                                                                                                                                                                                                            
                                                                                                                                                                                                                                         
  ### trace-store.ts                                                                                                                                                                                                                     
  - `diffToFindChangedLines()` - Compares old/new strings to identify only changed lines                                                                                                                                                 
  - `extractModelFromTranscript()` - Reads model from transcript tail (4KB initial read, doubles if needed)                                                                                                                              
                                                                                                                                                                                                                                         
  ### trace-hook.ts                                                                                                                                                                                                                      
  - `resolveModel()` - Transparently resolves model from payload (Cursor) or transcript (Claude Code)                                                                                                                                    
  - Updated `PostToolUse`, `SessionStart`, `SessionEnd` handlers                                                                                                                                                                         
                                                                                                                                                                                                                                         
  ## Test Results                                                                                                                                                                                                                        
                                                                                                                                                                                                                                         
  Tested with alternating Cursor and Claude Code edits in a sample repository:                                                                                                                                                           
                                                                                                                                                                                                                                         
  | Tool | Model | Lines | Verified |                                                                                                                                                                                                    
  |------|-------|-------|----------|                                                                                                                                                                                                    
  | Cursor | openai/gpt-5.2-codex | 67-70 | ✓ |                                                                                                                                                                                          
  | Claude Code | anthropic/claude-opus-4-5-20251101 | 71-74 | ✓ |                                                                                                                                                                       
  | Cursor | openai/gpt-5.2-codex | 75-78 | ✓ |                                                                                                                                                                                          
  | Claude Code | anthropic/claude-opus-4-5-20251101 | 79-82 | ✓ |                                                                                                                                                                       
                                                                                                                                                                                                                                         
  All traces correctly captured:                                                                                                                                                                                                         
  - Accurate line ranges matching actual file content                                                                                                                                                                                    
  - Model identification present for both tools                                                                                                                                                                                          
  - Transcript URLs properly linked                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  ## Backward Compatibility                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  - Cursor's `afterFileEdit` unchanged (uses explicit ranges from payload)                                                                                                                                                               
  - Diff logic only activates when both `old_string` and `new_string` are present                                                                                                                                                        
  - Model resolution falls back gracefully when transcript unavailable  